### PR TITLE
Some cleanup in the tests.

### DIFF
--- a/openmdao/devtools/tests/test_xdsm_viewer.py
+++ b/openmdao/devtools/tests/test_xdsm_viewer.py
@@ -25,7 +25,6 @@ FILENAME = 'XDSM'
 class TestXDSMViewer(unittest.TestCase):
 
     def setUp(self):
-        self.tstfile = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'mem_model.py')
         self.startdir = os.getcwd()
         self.tempdir = tempfile.mkdtemp(prefix='TestXDSMviewer-')
         os.chdir(self.tempdir)

--- a/openmdao/devtools/tests/test_xdsm_viewer.py
+++ b/openmdao/devtools/tests/test_xdsm_viewer.py
@@ -1,5 +1,10 @@
 import os
+import shutil
+import sys
+import tempfile
 import unittest
+
+from six import StringIO
 
 import numpy as np
 
@@ -19,6 +24,19 @@ FILENAME = 'XDSM'
 @unittest.skipUnless(XDSM, "XDSM is required.")
 class TestXDSMViewer(unittest.TestCase):
 
+    def setUp(self):
+        self.tstfile = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'mem_model.py')
+        self.startdir = os.getcwd()
+        self.tempdir = tempfile.mkdtemp(prefix='TestXDSMviewer-')
+        os.chdir(self.tempdir)
+
+    def tearDown(self):
+        os.chdir(self.startdir)
+        try:
+            shutil.rmtree(self.tempdir)
+        except OSError:
+            pass
+
     def test_pyxdsm_sellar(self):
         """Makes XDSM for the Sellar problem"""
         filename = FILENAME+'0'
@@ -35,7 +53,7 @@ class TestXDSMViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format='tex', show_browser=False)
+        write_xdsm(prob, filename=filename, out_format='tex', quiet=True, show_browser=False)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, 'tex'])))
 
@@ -56,7 +74,7 @@ class TestXDSMViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format='tex', show_browser=False, recurse=False)
+        write_xdsm(prob, filename=filename, out_format='tex', quiet=True, show_browser=False, recurse=False)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, 'tex'])))
 
@@ -99,7 +117,7 @@ class TestXDSMViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format='tex', show_browser=False)
+        write_xdsm(prob, filename=filename, out_format='tex', quiet=True, show_browser=False)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, 'tex'])))
 
@@ -153,19 +171,19 @@ class TestXDSMViewer(unittest.TestCase):
 
         p.run_model()
         # Test non unique local names
-        write_xdsm(p, 'xdsm3', out_format='tex', show_browser=False)
+        write_xdsm(p, 'xdsm3', out_format='tex', quiet=True, show_browser=False)
         self.assertTrue(os.path.isfile('.'.join(['xdsm3', 'tex'])))
         self.assertTrue(os.path.isfile('.'.join(['xdsm3', 'pdf'])))
 
         # Check formatting
 
         # Max character box formatting
-        write_xdsm(p, 'xdsm4', out_format='tex', show_browser=False,
+        write_xdsm(p, 'xdsm4', out_format='tex', quiet=True, show_browser=False,
                    box_stacking='cut_chars', box_width=15)
         self.assertTrue(os.path.isfile('.'.join(['xdsm4', 'tex'])))
         self.assertTrue(os.path.isfile('.'.join(['xdsm4', 'pdf'])))
         # Cut characters box formatting
-        write_xdsm(p, 'xdsm5', out_format='tex', show_browser=False,
+        write_xdsm(p, 'xdsm5', out_format='tex', quiet=True, show_browser=False,
                    box_stacking='max_chars', box_width=15)
         self.assertTrue(os.path.isfile('.'.join(['xdsm5', 'tex'])))
         self.assertTrue(os.path.isfile('.'.join(['xdsm5', 'pdf'])))
@@ -194,7 +212,7 @@ class TestXDSMViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format='html', subs=(), show_browser=False,
+        write_xdsm(prob, filename=filename, out_format='html', subs=(), show_browser=False, quiet=True,
                    embed_data=False)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, 'json'])))
@@ -221,7 +239,7 @@ class TestXDSMViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format='html', subs=(), show_browser=False,
+        write_xdsm(prob, filename=filename, out_format='html', subs=(), quiet=True, show_browser=False,
                    embed_data=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, 'html'])))
@@ -247,7 +265,7 @@ class TestXDSMViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format='html', subs=(), show_browser=False,
+        write_xdsm(prob, filename=filename, out_format='html', subs=(), quiet=True, show_browser=False,
                    embed_data=True, embeddable=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, 'html'])))
@@ -324,7 +342,7 @@ class TestXDSMViewer(unittest.TestCase):
 
         # no output checking, just make sure no exceptions raised
         with self.assertRaises(ValueError):
-            write_xdsm(prob, filename=filename, out_format='jpg', subs=(), show_browser=False)
+            write_xdsm(prob, filename=filename, out_format='jpg', subs=(), quiet=True, show_browser=False)
 
     def tearDown(self):
         """Set "clean_up" to False, if you want to inspect the output files."""

--- a/openmdao/devtools/tests/test_xdsm_viewer.py
+++ b/openmdao/devtools/tests/test_xdsm_viewer.py
@@ -4,8 +4,6 @@ import sys
 import tempfile
 import unittest
 
-from six import StringIO
-
 import numpy as np
 
 from openmdao.api import Problem, ExplicitComponent, IndepVarComp, ExecComp, ScipyOptimizeDriver, \

--- a/openmdao/devtools/xdsm_viewer/xdsm_writer.py
+++ b/openmdao/devtools/xdsm_viewer/xdsm_writer.py
@@ -407,7 +407,7 @@ def write_xdsm(problem, filename, model_path=None, recurse=True,
 def _write_xdsm(filename, viewer_data, optimizer=None, solver=None, cleanup=True,
                 design_vars=None, responses=None, residuals=None, model_path=None, recurse=True,
                 include_external_outputs=True, subs=_CHAR_SUBS, writer='pyXDSM',
-                show_browser=False, add_process_conns=True, **kwargs):
+                show_browser=False, add_process_conns=True, quiet=False, **kwargs):
     """
     XDSM writer. Components are extracted from the connections of the problem.
 
@@ -446,6 +446,9 @@ def _write_xdsm(filename, viewer_data, optimizer=None, solver=None, cleanup=True
     add_process_conns: bool
         Add process connections (thin black lines)
         Defaults to True
+    quiet : bool
+        Set to True to suppress output from pdflatex
+
     kwargs : dict
         Keyword arguments
 
@@ -553,7 +556,7 @@ def _write_xdsm(filename, viewer_data, optimizer=None, solver=None, cleanup=True
 
     if add_process_conns:
         x.add_workflow()
-    x.write(filename, cleanup=cleanup, **kwargs)
+    x.write(filename, cleanup=cleanup, quiet=quiet, **kwargs)
 
     if show_browser:
         # path will be specified based on the "out_format", if all required inputs where


### PR DESCRIPTION
1. Added a setup and teardown so that all files created during tests are cleaned up when the test concludes.
2. Added a new option to suppress the output from pdflatex -- requires modification to pyXDSM on my fork (PR pending approval.)